### PR TITLE
Add valence contracts to Osmosis

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2032,11 +2032,11 @@
     "valence-contracts-main": {
       "flake": false,
       "locked": {
-        "lastModified": 1743118505,
-        "narHash": "sha256-EMy3NNv7naemwcEI7fN1+kAaZQLxudRaOLBTM1iP9Cc=",
+        "lastModified": 1748888666,
+        "narHash": "sha256-u4ggiVVO1+lOsxN86TVXSfuMP5MCWoJuiyg352g2h2I=",
         "owner": "timewave-computer",
         "repo": "valence-protocol",
-        "rev": "9a37fe1dc2feafb5283879915bf8597776ffb443",
+        "rev": "91bb2e27311a36b85564ea2d4f50b95242297c14",
         "type": "github"
       },
       "original": {
@@ -2407,11 +2407,11 @@
         "valence-contracts-v0_1_2": "valence-contracts-v0_1_2"
       },
       "locked": {
-        "lastModified": 1745301944,
-        "narHash": "sha256-JcqC6ok0reUXXhB/eWc+UKpH5h22SeNhLUN4MfrpJyc=",
+        "lastModified": 1748991622,
+        "narHash": "sha256-OOfA0jaQpEsKmnGgVrfYKNSfnPdnDdY+9Ew9mCohubo=",
         "owner": "timewave-computer",
         "repo": "zero.nix",
-        "rev": "7b8ab9d28c8200308ff1314a406f98c14433d3b6",
+        "rev": "4335f1f0d43e0d4c5d12ab4065fef1ad10dcda7e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,11 @@
     timewave.cachix.org-1:nu3Uqsm3sikI9xFK3Mt4AD4Q6z+j6eS9+kND1vtznq4=
   '';
 
-  outputs = inputs @ {flake-parts, zero-nix, ...}:
+  outputs = inputs @ {
+    flake-parts,
+    zero-nix,
+    ...
+  }:
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = [
         "aarch64-darwin"
@@ -27,55 +31,59 @@
         # Adds all contracts in current release to all chains across networks
         zero-nix.flakeModules.valence-contracts
       ];
-      perSystem = { lib, config, inputs', ... }:
-        let zeroNixPkgs = inputs'.zero-nix.packages; in
-          {
-            valence-contracts.upload = false;
-            upload-contracts = {
-              network-defaults = { name, ... }: {
-                data-dir = "./${name}/contracts-data";
-                program-manager-chains-toml = ./${name}/chains.toml;
-                chain-defaults = {
-                  contract-defaults = {
-                    # Only use valence-contracts-main for contracts in list above
-                    package = lib.mkDefault zeroNixPkgs.valence-contracts-v0_1_2;
-                  };
-                  contracts = {
-                    # valence_drop_liquid_staker.package = zeroNixPkgs.valence-contracts-main;
-                    #valence_drop_liquid_unstaker.package = zeroNixPkgs.valence-contracts-main;
-                    valence_splitter_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                    valence_reverse_splitter_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                    valence_base_account.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                    valence_forwarder_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                    valence_processor.package = zeroNixPkgs.valence-contracts-v0_1_2; 
-                    valence_generic_ibc_transfer_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                    valence_osmosis_cl_lper.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                    valence_osmosis_cl_withdrawer.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                    valence_osmosis_gamm_lper.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                    valence_osmosis_gamm_withdrawer.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                  };
-                };
+      perSystem = {
+        lib,
+        inputs',
+        ...
+      }: let
+        zeroNixPkgs = inputs'.zero-nix.packages;
+      in {
+        valence-contracts.upload = false;
+        upload-contracts = {
+          network-defaults = {name, ...}: {
+            data-dir = "./${name}/contracts-data";
+            program-manager-chains-toml = ./${name}/chains.toml;
+            chain-defaults = {
+              contract-defaults = {
+                # Only use valence-contracts-main for contracts in list above
+                package = lib.mkDefault zeroNixPkgs.valence-contracts-v0_1_2;
               };
-              networks.mainnet.chains = {
-                neutron = {
-                  max-fees = "1000000";
-                };
-                juno = {
-                  max-fees = "1000000";
-                };
-                terra = {
-                  max-fees = "6000000";
-                };
-                osmosis = {
-                  max-fees = "1000000";
-                };
-              };
-              networks.testnet.chains = {
-                neutron = {
-                  max-fees = "1000000";
-                };
+              contracts = {
+                # valence_drop_liquid_staker.package = zeroNixPkgs.valence-contracts-main;
+                #valence_drop_liquid_unstaker.package = zeroNixPkgs.valence-contracts-main;
+                valence_splitter_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_reverse_splitter_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_base_account.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_forwarder_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_processor.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_generic_ibc_transfer_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_osmosis_cl_lper.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_osmosis_cl_withdrawer.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_osmosis_gamm_lper.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                valence_osmosis_gamm_withdrawer.package = zeroNixPkgs.valence-contracts-v0_1_2;
               };
             };
           };
+          networks.mainnet.chains = {
+            neutron = {
+              max-fees = "1000000";
+            };
+            juno = {
+              max-fees = "1000000";
+            };
+            terra = {
+              max-fees = "6000000";
+            };
+            osmosis = {
+              max-fees = "1000000";
+            };
+          };
+          networks.testnet.chains = {
+            neutron = {
+              max-fees = "1000000";
+            };
+          };
+        };
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -38,35 +38,25 @@
       }: let
         zeroNixPkgs = inputs'.zero-nix.packages;
       in {
-        valence-contracts.upload = false;
+        valence-contracts.upload = true;
         upload-contracts = {
           network-defaults = {name, ...}: {
             data-dir = "./${name}/contracts-data";
             program-manager-chains-toml = ./${name}/chains.toml;
             chain-defaults = {
               contract-defaults = {
-                # Only use valence-contracts-main for contracts in list above
+                # Use contracts from release by default
                 package = lib.mkDefault zeroNixPkgs.valence-contracts-v0_1_2;
-              };
-              contracts = {
-                # valence_drop_liquid_staker.package = zeroNixPkgs.valence-contracts-main;
-                #valence_drop_liquid_unstaker.package = zeroNixPkgs.valence-contracts-main;
-                valence_splitter_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_reverse_splitter_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_base_account.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_forwarder_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_processor.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_generic_ibc_transfer_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_osmosis_cl_lper.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_osmosis_cl_withdrawer.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_osmosis_gamm_lper.package = zeroNixPkgs.valence-contracts-v0_1_2;
-                valence_osmosis_gamm_withdrawer.package = zeroNixPkgs.valence-contracts-v0_1_2;
               };
             };
           };
           networks.mainnet.chains = {
             neutron = {
               max-fees = "1000000";
+              contracts = {
+                valence_drop_liquid_staker.package = zeroNixPkgs.valence-contracts-main;
+                valence_drop_liquid_unstaker.package = zeroNixPkgs.valence-contracts-main;
+              };
             };
             juno = {
               max-fees = "1000000";
@@ -76,6 +66,10 @@
             };
             osmosis = {
               max-fees = "1000000";
+              contracts = {
+                valence_astroport_lper.enable = false;
+                valence_astroport_withdrawer.enable = false;
+              };
             };
           };
           networks.testnet.chains = {

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
               contracts = {
                 valence_astroport_lper.enable = false;
                 valence_astroport_withdrawer.enable = false;
+                valence_mars_lending.package = zeroNixPkgs.valence-contracts-main;
               };
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       perSystem = { lib, config, inputs', ... }:
         let zeroNixPkgs = inputs'.zero-nix.packages; in
           {
-            valence-contracts.upload = true;
+            valence-contracts.upload = false;
             upload-contracts = {
               network-defaults = { name, ... }: {
                 data-dir = "./${name}/contracts-data";
@@ -41,8 +41,18 @@
                     package = lib.mkDefault zeroNixPkgs.valence-contracts-v0_1_2;
                   };
                   contracts = {
-                    valence_drop_liquid_staker.package = zeroNixPkgs.valence-contracts-main;
-                    valence_drop_liquid_unstaker.package = zeroNixPkgs.valence-contracts-main;
+                    # valence_drop_liquid_staker.package = zeroNixPkgs.valence-contracts-main;
+                    #valence_drop_liquid_unstaker.package = zeroNixPkgs.valence-contracts-main;
+                    valence_splitter_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                    valence_reverse_splitter_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                    valence_base_account.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                    valence_forwarder_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                    valence_processor.package = zeroNixPkgs.valence-contracts-v0_1_2; 
+                    valence_generic_ibc_transfer_library.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                    valence_osmosis_cl_lper.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                    valence_osmosis_cl_withdrawer.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                    valence_osmosis_gamm_lper.package = zeroNixPkgs.valence-contracts-v0_1_2;
+                    valence_osmosis_gamm_withdrawer.package = zeroNixPkgs.valence-contracts-v0_1_2;
                   };
                 };
               };
@@ -55,6 +65,9 @@
                 };
                 terra = {
                   max-fees = "6000000";
+                };
+                osmosis = {
+                  max-fees = "1000000";
                 };
               };
               networks.testnet.chains = {

--- a/mainnet/chains.toml
+++ b/mainnet/chains.toml
@@ -29,3 +29,13 @@ prefix    = "terra"
 gas_price = "0.015"
 gas_denom = "uluna"
 coin_type = "330"
+
+[chains.osmosis]
+chain_id = "osmosis-1"
+name = "osmosis"
+rpc  = "https://osmosis-rpc.polkachu.com:443"
+grpc = "https://osmosis-grpc.polkachu.com:11790"
+prefix    = "osmo"
+gas_price = "0.015"
+gas_denom = "uosmo"
+coin_type = "118"

--- a/mainnet/contracts-data/osmosis.yaml
+++ b/mainnet/contracts-data/osmosis.yaml
@@ -1,3 +1,7 @@
+valence_mars_lending:
+  code_id: '1619'
+  hash: f022aa3eb06dcdade2bb9dd2b6c3aa730d0c3e53a680fc504e0051ac6fd67271
+  source: 91bb2e27311a36b85564ea2d4f50b95242297c14
 valence_splitter_library:
   code_id: '1620'
   hash: 425ac4a38090bfba13bf2db78894f9de0f2d09031c9f36b5e3e41bb4d966194a

--- a/mainnet/contracts-data/osmosis.yaml
+++ b/mainnet/contracts-data/osmosis.yaml
@@ -1,0 +1,40 @@
+valence_splitter_library:
+  code_id: '1620'
+  hash: 425ac4a38090bfba13bf2db78894f9de0f2d09031c9f36b5e3e41bb4d966194a
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_base_account:
+  code_id: '1621'
+  hash: 6ece232677d7c61e866dea3cf936a3e61afe28c30c124987a2fe623b496f7882
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_forwarder_library:
+  code_id: '1622'
+  hash: 0845a9eb22783e30c166978d465ad43931cff708a53667e524e471a7e5b1e42a
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_generic_ibc_transfer_library:
+  code_id: '1623'
+  hash: 70828076e2f4e58648f368b6aa237d1718ca80eb8233e682a85989739ba2df3a
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_osmosis_cl_lper:
+  code_id: '1624'
+  hash: 1ec7757b05afd87bc70cc2ef18525a0d13b8e6e38b777031386e0195eb256bea
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_osmosis_cl_withdrawer:
+  code_id: '1625'
+  hash: e6c6b44f4ea2165ffe9b8c378e8b8f18e5f6aeff12d4e1d9145dc1775b8aea7b
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_osmosis_gamm_lper:
+  code_id: '1626'
+  hash: 17efb3553354ab5340625f52517953d8c51040dce4fa9b99a48d46847831cb6d
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_osmosis_gamm_withdrawer:
+  code_id: '1627'
+  hash: dbf9e4ee350846c14a78ef393c5f0cf0b7589e405d00a8161cf72d0e5b4cfe3b
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_processor:
+  code_id: '1628'
+  hash: 5ac61ef6b5969e812162745b9afe9c2c45fa1cfa30ddea554b9e5bad9bdf5ed3
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299
+valence_reverse_splitter_library:
+  code_id: '1629'
+  hash: 3e63a03bb1dc0e2fb24c384629b4d6a7240c2af87c0055db6c03eb7285871fe8
+  source: 16e604bcdeb54d9b458809487166b8e9c3371299


### PR DESCRIPTION
I've stored contracts on Osmosis. I added workarounds in flake.nix to avoid storing all contracts on Osmosis (e.g., Astroport, Drop). @Pacman99 will be cleaning up Zero.Nix to accomodate selective contract uploading per chain. 

Thanks @Pacman99 for the support. Feel free to continue cleaning up this branch or close this PR and create a fresh one with the cleaner code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Osmosis chain, including detailed configuration and integration.
  - Introduced a new contracts data file for Osmosis mainnet, listing multiple smart contracts and their attributes.
- **Enhancements**
  - Improved configuration structure for better readability and future extensibility.
  - Clarified contract package assignments for mainnet chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->